### PR TITLE
Add CFLAGS to gcc command

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,3 +1,3 @@
 
 compile:
-	gcc vmq_passwd.c -lcrypto -o vmq_passwd
+	gcc $(CFLAGS) vmq_passwd.c -lcrypto -o vmq_passwd


### PR DESCRIPTION
this allows passing specific e.g. openssl include paths
